### PR TITLE
Ignore all IDE config files from PyCharm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .vscode/
 temporary.db
 
+# PyCharm ignore all
+.idea/*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Ignore all files in `.idea/` folder initialized by PyCharm IDE. Some files in `.idea/` contain user-specific settings[[1](https://intellij-support.jetbrains.com/hc/en-us/articles/206544839)]:

- File: `workspace.xml`
- File: `usage.statistics.xml`
- Directory: `shelf/`