### PR TITLE
Specified possible error types on bare except

### DIFF
--- a/app/ocr.py
+++ b/app/ocr.py
@@ -170,7 +170,7 @@ class BIACase:
             sent_before_start = self.doc[start - 1].sent.start
             sent_after_end: int
             sent_after_end = self.doc[end + 1].sent.end
-        except IndexError:
+        except (IndexError, AttributeError):
             return token.sent
 
         surrounding: Span

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -170,7 +170,9 @@ class BIACase:
             sent_before_start = self.doc[start - 1].sent.start
             sent_after_end: int
             sent_after_end = self.doc[end + 1].sent.end
-        except:
+
+        # TODO: Check if this is the only error type
+        except IndexError:
             return token.sent
 
         surrounding: Span

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -170,8 +170,6 @@ class BIACase:
             sent_before_start = self.doc[start - 1].sent.start
             sent_after_end: int
             sent_after_end = self.doc[end + 1].sent.end
-
-        # TODO: Check if this is the only error type
         except IndexError:
             return token.sent
 


### PR DESCRIPTION
Function `get_surrounding_sents()` had a bare except. Based on operation occurring before try; two possible errors could occur:

- `IndexError` if value of `start` or `end` are outside of index range.
- `AttributeError` if type is of `None`