### PR TITLE
Focus `get_gender()` pronoun search near keywords

### DIFF
--- a/app/ocr.py
+++ b/app/ocr.py
@@ -13,7 +13,7 @@ from spacy import load
 from spacy.tokens.doc import Doc
 from spacy.tokens.span import Span
 from spacy.tokens.token import Token
-from spacy.matcher import Matcher
+from spacy.matcher import Matcher, PhraseMatcher
 
 nlp = load("en_core_web_sm")
 
@@ -466,25 +466,21 @@ class BIACase:
 
     def get_gender(self) -> str:
         """
-        • This field needs to be validated. Currently, it assumes the
-        sex of the seeker by the number of instances of pronouns in the
-        document.
+        Based on sentences where the Respondent/Applicant keywords are found,
+        count the instances of gendered pronouns. This approach assumes the
+        sentence refers to subject in shorthand by using gendered pronouns
+        as opposed to keywords multiple times in sentence. This function
+        returns a final result to be packaged into json.
+
+        Parameters:
+        spacy.doc (obj):
+
+        Returns:
+        str: Gender
+
         """
-        male = 0
-        female = 0
 
-        for token in self.doc:
-            if token.text in {'him', 'his', 'he'}:
-                male += 1
-            elif token.text in {'her', 'hers', 'she'}:
-                female += 1
 
-        if male > female:
-            return 'male'
-        elif female > male:
-            return 'female'
-        else:
-            return 'unknown'
 
     def get_indigenous_status(self) -> str:
         """

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -507,7 +507,24 @@ class BIACase:
                 if nlp.vocab.strings[match_id] in ['RESP']:
                     found += sentences.text
 
+            # Pass string of sentences with target phrases to tag POS
+            found_nlp = nlp(found)
 
+            # Count instances of part-of-speech tagged as pronouns in sentences
+            for word_pos in found_nlp:
+                if word_pos.pos_ == 'PRON':
+                    if word_pos.text.lower() in male_prons:
+                        male_count += 1
+                    elif word_pos.text.lower() in female_prons:
+                        female_count += 1
+
+            # Analyze highest count and return that gender or empty string for equal
+            if female_count > male_count:
+                return "Female"
+            elif male_count > female_count:
+                return "Male"
+            else:
+                return ""
 
     def get_indigenous_status(self) -> str:
         """

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -489,6 +489,11 @@ class BIACase:
         male_prons = ['he', 'He', "He's", "he's", 'his']
         female_prons = ['she', 'She', "She's", "she's", 'hers']
 
+        # Variables for analysis storage
+        male_count = 0
+        female_count = 0
+        found = ""
+
 
 
     def get_indigenous_status(self) -> str:

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -482,12 +482,12 @@ class BIACase:
 
         # Search terms formatted
         phrases = ["Respondent's", "Respondent", "respondent's", "respondent",
-                   "Applicant", "applicant", "Applicant's", "applicant's"]
+                   "Applicant", "applicant", "Applicant's", "applicant's", 'filed an application']
         patterns = [nlp(text) for text in phrases]
 
         # Gender constants
-        male_prons = ['he', 'He', "He's", "he's", 'his']
-        female_prons = ['she', 'She', "She's", "she's", 'hers']
+        male_prons = ['he', "he's", 'his', 'himself']
+        female_prons = ['she', "she's", 'her', 'herself']
 
         # Variables for analysis storage
         male_count = 0

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -507,24 +507,24 @@ class BIACase:
                 if nlp.vocab.strings[match_id] in ['RESP']:
                     found += sentences.text
 
-            # Pass string of sentences with target phrases to tag POS
-            found_nlp = nlp(found)
+        # Pass string of sentences with target phrases to tag POS
+        found_nlp = nlp(found)
 
-            # Count instances of part-of-speech tagged as pronouns in sentences
-            for word_pos in found_nlp:
-                if word_pos.pos_ == 'PRON':
-                    if word_pos.text.lower() in male_prons:
-                        male_count += 1
-                    elif word_pos.text.lower() in female_prons:
-                        female_count += 1
+        # Count instances of part-of-speech tagged as pronouns in sentences
+        for word_pos in found_nlp:
+            if word_pos.pos_ == 'PRON':
+                if word_pos.text.lower() in male_prons:
+                    male_count += 1
+                elif word_pos.text.lower() in female_prons:
+                    female_count += 1
 
-            # Analyze highest count and return that gender or empty string for equal
-            if female_count > male_count:
-                return "Female"
-            elif male_count > female_count:
-                return "Male"
-            else:
-                return ""
+        # Analyze highest count and return that gender or empty string for equal
+        if female_count > male_count:
+            return "Female"
+        elif male_count > female_count:
+            return "Male"
+        else:
+            return ""
 
     def get_indigenous_status(self) -> str:
         """

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -494,6 +494,10 @@ class BIACase:
         female_count = 0
         found = ""
 
+        # PhraseMatcher setup, add tag (RESP) and pass in patterns
+        phrase_matcher = PhraseMatcher(nlp.vocab)
+        phrase_matcher.add("RESP", None, *patterns)
+
 
 
     def get_indigenous_status(self) -> str:

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -485,6 +485,10 @@ class BIACase:
                    "Applicant", "applicant", "Applicant's", "applicant's"]
         patterns = [nlp(text) for text in phrases]
 
+        # Gender constants
+        male_prons = ['he', 'He', "He's", "he's", 'his']
+        female_prons = ['she', 'She', "She's", "she's", 'hers']
+
 
 
     def get_indigenous_status(self) -> str:

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -498,7 +498,8 @@ class BIACase:
         phrase_matcher = PhraseMatcher(nlp.vocab)
         phrase_matcher.add("RESP", None, *patterns)
 
-
+        # Pass in doc into PhraseMatcher
+        matches = phrase_matcher(self.doc)
 
     def get_indigenous_status(self) -> str:
         """

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -501,6 +501,14 @@ class BIACase:
         # Pass in doc into PhraseMatcher
         matches = phrase_matcher(self.doc)
 
+        # Append all sentences with target-tag to string storage variable
+        for sentences in self.doc.sents:
+            for match_id, start, end in phrase_matcher(nlp(sentences.text)):
+                if nlp.vocab.strings[match_id] in ['RESP']:
+                    found += sentences.text
+
+
+
     def get_indigenous_status(self) -> str:
         """
         • If the term "indigenous" appears in the document, the field will return

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -480,6 +480,11 @@ class BIACase:
 
         """
 
+        # Search terms formatted
+        phrases = ["Respondent's", "Respondent", "respondent's", "respondent",
+                   "Applicant", "applicant", "Applicant's", "applicant's"]
+        patterns = [nlp(text) for text in phrases]
+
 
 
     def get_indigenous_status(self) -> str:


### PR DESCRIPTION
New implementation of `get_gender()` to count pronouns in sentences where keywords/phrases are found. 
This approach assumes the subject of the sentence was established with the keyword and their pronoun was used to refer to the subject in shorthand.