### PR TITLE
Replace old README with new README

### DIFF
--- a/Labs32README.md
+++ b/Labs32README.md
@@ -1,0 +1,114 @@
+# Human Rights First - Asylum
+An application to assist immigration attorneys and refugee representatives in advocating for clients in asylum cases by identifying patterns in judicial decisions and predicting possible outcomes based on those patterns.
+
+## Description
+We participated in the building of an application for human rights first, a 501(c)3 organization. Our application uses optical character recognition to scan input court decisions for such values as the name of the presiding judge, the decision, and the asylum seeker's country of origin, and inserts these values into a database. The hope is that advocates for asylum seekers can use these data to better tailor their arguments before a particular judge and maximize their client's chances of receiving asylum. To use the application offline, follow the steps under Installation.
+
+## Architecture
+![image](assets/HRF_architecture_diagram_DavidH_rjproctor.png)
+
+## Process
+*  The stakeholder provided documents that became the foundation of our database schema.  We built database, scraped pdf documents from the internet, and filtered from them asylum cases only to populate the corpus of documents in our database.
+
+*  Each pdf document was read using optical character recognition (OCR), converted to text to plain text and then to json which allowed us to search through each document and retrieve keywords.  These keywords will become fields in tables in our relational database.
+
+*  We created an API connecting the database to the web development back-end with the result that user uploaded case files can be inserted into the database.
+
+*  We created a model that, once the database has persisting data, and the model is adjusted to the specificity of that data, will predict a possible outcome of an individual judge's or panels of judges decision(s) based on his/her/their past rulings of similar cases.  This model will also render results that display easy to interpret and use (from UX perspective) visualizations on micro-patterns within the data
+
+## Time structures
+Each team worked in weekly sprints with a total time constraint of one month for the total project.  Teams met with stakeholder(s) during each sprint to present progress, ask questions, receive feedback and explore evolving stakeholder expectations.  The structure of each sprint was set:
+  * Week 1 - Planning
+  * Week 2 & 3 Working the Plan (coding and revising the plan according to evolving stakeholder needs and new understandings of the business problem)
+  * Week 4 - Documentation and Presenting Work
+
+Labs 29 chose to work together on all tasks and accomplished:
+  * create an empty database with no schema
+  * create a PDF scraper using OCR that converted PDF images to text
+  * create a pathway to completion of FastAPI
+
+Labs 30 chose to work asynchronously, yet supporting one another through pair-coding sessions and peer reviews and acomplished:
+  * creating a relational database with [schema](assets/HRF_DS_DB_schema_diagram_SeanB.png)
+  * completed connections between FastAPI and the back-end of the web application
+  * adapting Team 1's PDF scraper to filter out only asylum cases and then convert PDF images to text and then to json
+  * create a PDF scraper for search terms in all categories except social groups (time constraints)
+  * explore alternative scraping methods for PDFs and keywords in search of efficiencies
+  * create a pathway for data processing, model and visualization completion once there is persistent data
+
+Labs 31 chose to work asynchronously, yet supporting one another through pair-coding sessions and peer reviews and acomplished:
+  * created an API hook implementing the scraper and OCR that returns a json object of fields the scraper finds in a PDF
+  * created new fields for the scraper to search for
+  * started the process of deploying the API
+  * refined the dockerfile for fixing dependency issues
+  * started refining the scraper class
+
+Labs 32 chose to work collaboratively in order to achieve:
+  * aligned our endpoints to those of the FE & BE Web teams
+  * further refined dockfile for AWS Elastic Beanstalk
+  * deployed the functional scraper application to AWS EB
+  * code now reads files from BE connected S3 bucket
+  * started creating visualizations for FE implementation
+
+## Next Steps
+Inside our team’s Google Drive you will find two important documents. A screenshot of a Product Road Map and a description of tasks associated with the road map. Please reference that for additional user stories such as:
+  * An additional field of Criminal Record, return a paragraph of crime associated if so
+  * Interactive World and USA map to check statistics on who is approved or denied
+  * Itterating on visuals to make them 
+
+## Tools
+
+ * [Pytesseract](https://github.com/madmaze/pytesseract)
+ * [FastAPI](https://github.com/tiangolo/fastapi)
+ * [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/)
+
+## Installation
+
+ After cloning the repository, in your command line run the following commands:
+ Replace <name> with a name of your choice.
+ ```
+docker build . -t <name>
+docker run -it -p 5000:5000 <name> uvicorn app.main:app --host=0.0.0.0 --port=5000
+
+NOTE: An error may be thrown when trying to run the app if you have not added the .env file with aws credentials
+ ```
+ Then open http://0.0.0.0:5000 in your browser. The application should be running. 
+
+ ## Contributors
+
+ [Bharath Gogineni, Labs32](https://github.com/begogineni)
+
+ [Jace Hambrick, Labs32](https://github.com/Jace-Hambrick)
+
+ [Nicholas Adamski, Labs32](https://github.com/boscolio)
+
+ [Rassamy J. Soumphonphakdy, Labs32](https://github.com/rassamyjs)
+
+ [Rebecca Duke Wiesenberg, Labs31](https://github.com/rdukewiesenb)
+
+ [Reid Harris, Labs31](https://github.com/codealamode)
+
+ [Lucas Petrus, Labs31](https://github.com/lucaspetrus)
+
+ [Noah Caldwell, Labs31](https://github.com/noahnisbet)
+
+ [Tomas Phillips, Labs30](https://github.com/tomashphill)
+
+ [Sean Byrne, Labs30](https://github.com/ssbyrne89)
+
+ [Henry Gultom, Labs30](https://github.com/henryspg)
+ 
+ [RJ Proctor, Labs30](https://github.com/jproctor-rebecca)
+
+ [Liam Cloud Hogan, Labs29](https://github.com/liam-cloud-hogan)
+ 
+ [Steven Lee, Labs29](https://github.com/StevenBryceLee)
+
+ [Edwina Palmer, Labs29](https://github.com/edwinapalmer)
+
+ [Tristan Brown, Labs29](https://github.com/Tristan-Brown1096)
+ 
+![Team2 Cross-functional Whole Team Structure](assets/HRF_cross_functional_product_dev_team_rjproctor.png)
+
+ ## License
+
+ This project is licensed under the terms of the MIT license.

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ An application to assist immigration attorneys and refugee representatives in ad
 
 
 ## Architecture
-![image](https://github.com/Lambda-School-Labs/human-rights-first-asylum-be-a/blob/main/reference/architecture.png?raw=true)
+![image](https://github.com/Lambda-School-Labs/human-rights-first-asylum-be-a/blob/main/reference/architecture.png?raw=true)  
 This diagram shows the current state of the architecture.
 
 ## Codebases
-[Front-End](https://github.com/Lambda-School-Labs/human-rights-first-asylum-fe-a/blob/main/README.md)
+[Front-End](https://github.com/Lambda-School-Labs/human-rights-first-asylum-fe-a/blob/main/README.md)  
 Uses NodeJS to create the web-based user interface for uploading case documents, managing users, and viewing data in the form of tables and visualizations. 
 
-[Back-End](https://github.com/Lambda-School-Labs/human-rights-first-asylum-be-a/blob/main/README.md)
+[Back-End](https://github.com/Lambda-School-Labs/human-rights-first-asylum-be-a/blob/main/README.md)  
 Uses Javascript and Postgres to manage databases containing tables for users, judges, and cases.
 
-[Data Science](https://github.com/Lambda-School-Labs/human-rights-first-asylum-ds-a/blob/main/README.md)
+[Data Science](https://github.com/Lambda-School-Labs/human-rights-first-asylum-ds-a/blob/main/README.md)  
 Uses Python and Tesseract for optical character recognition (OCR) to convert pdf images into text data that can be searched via natural language processing (NLP) techniques. Key data, which we refer to as structured fields, are extracted from the text data and sent to the back-end for storage.
 
 ## Our Role
@@ -35,49 +35,49 @@ Brief description of what's in this repo. Break down based on folder.
 
 ## Installation
 
- After cloning the repository, in your command line run the following commands:
- Replace <name> with a name of your choice.
- ```
+After cloning the repository, in your command line run the following commands:
+Replace <name> with a name of your choice.
+```
 docker build . -t <name>
 docker run -it -p 5000:5000 <name> uvicorn app.main:app --host=0.0.0.0 --port=5000
-
 NOTE: An error may be thrown when trying to run the app if you have not added the .env file with aws credentials
- ```
- Then open http://0.0.0.0:5000 in your browser. The application should be running. 
+```
+
+Then open http://0.0.0.0:5000 in your browser. The application should be running. 
 
 ## Contributors
 ###### Labs 33
-[Michael Kolek](https://github.com/InqM)
-[Francis LaBounty](https://github.com/francislabountyjr)
-[Jennifer Faith](https://github.com/JenFaith)
-[Brett Doffing](https://github.com/doffing81)
-[Daniel Fernandez](https://github.com/Daniel-Fernandez-951)
-[Kevin Weatherwalks](https://github.com/KWeatherwalks)
+[Michael Kolek](https://github.com/InqM)  
+[Francis LaBounty](https://github.com/francislabountyjr)  
+[Jennifer Faith](https://github.com/JenFaith)  
+[Brett Doffing](https://github.com/doffing81)  
+[Daniel Fernandez](https://github.com/Daniel-Fernandez-951)  
+[Kevin Weatherwalks](https://github.com/KWeatherwalks)  
 
 ###### Labs 32
- [Bharath Gogineni](https://github.com/begogineni)
- [Jace Hambrick](https://github.com/Jace-Hambrick)
- [Nicholas Adamski](https://github.com/boscolio)
- [Rassamy J. Soumphonphakdy](https://github.com/rassamyjs)
+[Bharath Gogineni](https://github.com/begogineni)  
+[Jace Hambrick](https://github.com/Jace-Hambrick)  
+[Nicholas Adamski](https://github.com/boscolio)  
+[Rassamy J. Soumphonphakdy](https://github.com/rassamyjs)  
 
 ###### Labs 31
- [Rebecca Duke Wiesenberg](https://github.com/rdukewiesenb)
- [Reid Harris](https://github.com/codealamode)
- [Lucas Petrus](https://github.com/lucaspetrus)
- [Noah Caldwell](https://github.com/noahnisbet)
+[Rebecca Duke Wiesenberg](https://github.com/rdukewiesenb)  
+[Reid Harris](https://github.com/codealamode)  
+[Lucas Petrus](https://github.com/lucaspetrus)  
+[Noah Caldwell](https://github.com/noahnisbet)  
 
 ###### Labs 30
-[Tomas Phillips](https://github.com/tomashphill)
-[Sean Byrne](https://github.com/ssbyrne89)
-[Henry Gultom](https://github.com/henryspg)
-[RJ Proctor](https://github.com/jproctor-rebecca)
+[Tomas Phillips](https://github.com/tomashphill)  
+[Sean Byrne](https://github.com/ssbyrne89)  
+[Henry Gultom](https://github.com/henryspg)  
+[RJ Proctor](https://github.com/jproctor-rebecca)  
 
 ###### Labs 29
-[Liam Cloud Hogan](https://github.com/liam-cloud-hogan)
-[Steven Lee](https://github.com/StevenBryceLee)
-[Edwina Palmer](https://github.com/edwinapalmer)
-[Tristan Brown](https://github.com/Tristan-Brown1096)
+[Liam Cloud Hogan](https://github.com/liam-cloud-hogan)  
+[Steven Lee](https://github.com/StevenBryceLee)  
+[Edwina Palmer](https://github.com/edwinapalmer)  
+[Tristan Brown](https://github.com/Tristan-Brown1096)  
 
 
- ## License
- This project is licensed under the terms of the MIT license.
+## License
+This project is licensed under the terms of the MIT license.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Then open http://0.0.0.0:5000 in your browser. The application should be running
 [Jennifer Faith](https://github.com/JenFaith)  
 [Brett Doffing](https://github.com/doffing81)  
 [Daniel Fernandez](https://github.com/Daniel-Fernandez-951)  
-[Kevin Weatherwalks](https://github.com/KWeatherwalks)  
+[Kevin Weatherwalks](https://github.com/KWeatherwalks)   
+[Alex Krieger](https://github.com/kriegersaurusrex)  
 
 ###### Labs 32
 [Bharath Gogineni](https://github.com/begogineni)  

--- a/README.md
+++ b/README.md
@@ -1,65 +1,37 @@
 # Human Rights First - Asylum
 An application to assist immigration attorneys and refugee representatives in advocating for clients in asylum cases by identifying patterns in judicial decisions and predicting possible outcomes based on those patterns.
 
-## Description
-We participated in the building of an application for human rights first, a 501(c)3 organization. Our application uses optical character recognition to scan input court decisions for such values as the name of the presiding judge, the decision, and the asylum seeker's country of origin, and inserts these values into a database. The hope is that advocates for asylum seekers can use these data to better tailor their arguments before a particular judge and maximize their client's chances of receiving asylum. To use the application offline, follow the steps under Installation.
+## Product Mission and Goals
+[Human Rights First (HRF)](https://www.humanrightsfirst.org/about) is a non-profit, nonpartisan, 501(c)(3), international human rights organization based in New York, Washington D.C., Houston, and Los Angeles. [HRF](https://www.humanrightsfirst.org/asylum) works to link immigration attorneys and advocates with asylum seekers and provide those attorneys with resources to represent their clients. Our application leverages historical data to inform advocates better of a judge's past decisions. The hope is that advocates for asylum seekers can use our tools to tailor their arguments before a particular judge and maximize their client's chances of receiving asylum.
+
+
 
 ## Architecture
-![image](assets/HRF_architecture_diagram_DavidH_rjproctor.png)
+![image](https://github.com/Lambda-School-Labs/human-rights-first-asylum-be-a/blob/main/reference/architecture.png?raw=true)
+This diagram shows the current state of the architecture.
 
-## Process
-*  The stakeholder provided documents that became the foundation of our database schema.  We built database, scraped pdf documents from the internet, and filtered from them asylum cases only to populate the corpus of documents in our database.
+## Codebases
+[Front-End](https://github.com/Lambda-School-Labs/human-rights-first-asylum-fe-a/blob/main/README.md)
+Uses NodeJS to create the web-based user interface for uploading case documents, managing users, and viewing data in the form of tables and visualizations. 
 
-*  Each pdf document was read using optical character recognition (OCR), converted to text to plain text and then to json which allowed us to search through each document and retrieve keywords.  These keywords will become fields in tables in our relational database.
+[Back-End](https://github.com/Lambda-School-Labs/human-rights-first-asylum-be-a/blob/main/README.md)
+Uses Javascript and Postgres to manage databases containing tables for users, judges, and cases.
 
-*  We created an API connecting the database to the web development back-end with the result that user uploaded case files can be inserted into the database.
+[Data Science](https://github.com/Lambda-School-Labs/human-rights-first-asylum-ds-a/blob/main/README.md)
+Uses Python and Tesseract for optical character recognition (OCR) to convert pdf images into text data that can be searched via natural language processing (NLP) techniques. Key data, which we refer to as structured fields, are extracted from the text data and sent to the back-end for storage.
 
-*  We created a model that, once the database has persisting data, and the model is adjusted to the specificity of that data, will predict a possible outcome of an individual judge's or panels of judges decision(s) based on his/her/their past rulings of similar cases.  This model will also render results that display easy to interpret and use (from UX perspective) visualizations on micro-patterns within the data
+## Our Role
+What we have done and need to do to move the project forward.
 
-## Time structures
-Each team worked in weekly sprints with a total time constraint of one month for the total project.  Teams met with stakeholder(s) during each sprint to present progress, ask questions, receive feedback and explore evolving stakeholder expectations.  The structure of each sprint was set:
-  * Week 1 - Planning
-  * Week 2 & 3 Working the Plan (coding and revising the plan according to evolving stakeholder needs and new understandings of the business problem)
-  * Week 4 - Documentation and Presenting Work
+## Files
+Brief description of what's in this repo. Break down based on folder.
 
-Labs 29 chose to work together on all tasks and accomplished:
-  * create an empty database with no schema
-  * create a PDF scraper using OCR that converted PDF images to text
-  * create a pathway to completion of FastAPI
-
-Labs 30 chose to work asynchronously, yet supporting one another through pair-coding sessions and peer reviews and acomplished:
-  * creating a relational database with [schema](assets/HRF_DS_DB_schema_diagram_SeanB.png)
-  * completed connections between FastAPI and the back-end of the web application
-  * adapting Team 1's PDF scraper to filter out only asylum cases and then convert PDF images to text and then to json
-  * create a PDF scraper for search terms in all categories except social groups (time constraints)
-  * explore alternative scraping methods for PDFs and keywords in search of efficiencies
-  * create a pathway for data processing, model and visualization completion once there is persistent data
-
-Labs 31 chose to work asynchronously, yet supporting one another through pair-coding sessions and peer reviews and acomplished:
-  * created an API hook implementing the scraper and OCR that returns a json object of fields the scraper finds in a PDF
-  * created new fields for the scraper to search for
-  * started the process of deploying the API
-  * refined the dockerfile for fixing dependency issues
-  * started refining the scraper class
-
-Labs 32 chose to work collaboratively in order to achieve:
-  * aligned our endpoints to those of the FE & BE Web teams
-  * further refined dockfile for AWS Elastic Beanstalk
-  * deployed the functional scraper application to AWS EB
-  * code now reads files from BE connected S3 bucket
-  * started creating visualizations for FE implementation
-
-## Next Steps
-Inside our team’s Google Drive you will find two important documents. A screenshot of a Product Road Map and a description of tasks associated with the road map. Please reference that for additional user stories such as:
-  * An additional field of Criminal Record, return a paragraph of crime associated if so
-  * Interactive World and USA map to check statistics on who is approved or denied
-  * Itterating on visuals to make them 
 
 ## Tools
 
- * [Pytesseract](https://github.com/madmaze/pytesseract)
- * [FastAPI](https://github.com/tiangolo/fastapi)
- * [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/)
+ * [Pytesseract](https://github.com/madmaze/pytesseract) - package for converting pdfs to text
+ * [FastAPI](https://github.com/tiangolo/fastapi) - API for endpoint that processes pdfs
+ * [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/) - Service for app deployment
 
 ## Installation
 
@@ -73,42 +45,39 @@ NOTE: An error may be thrown when trying to run the app if you have not added th
  ```
  Then open http://0.0.0.0:5000 in your browser. The application should be running. 
 
- ## Contributors
+## Contributors
+###### Labs 33
+[Michael Kolek](https://github.com/InqM)
+[Francis LaBounty](https://github.com/francislabountyjr)
+[Jennifer Faith](https://github.com/JenFaith)
+[Brett Doffing](https://github.com/doffing81)
+[Daniel Fernandez](https://github.com/Daniel-Fernandez-951)
+[Kevin Weatherwalks](https://github.com/KWeatherwalks)
 
- [Bharath Gogineni, Labs32](https://github.com/begogineni)
+###### Labs 32
+ [Bharath Gogineni](https://github.com/begogineni)
+ [Jace Hambrick](https://github.com/Jace-Hambrick)
+ [Nicholas Adamski](https://github.com/boscolio)
+ [Rassamy J. Soumphonphakdy](https://github.com/rassamyjs)
 
- [Jace Hambrick, Labs32](https://github.com/Jace-Hambrick)
+###### Labs 31
+ [Rebecca Duke Wiesenberg](https://github.com/rdukewiesenb)
+ [Reid Harris](https://github.com/codealamode)
+ [Lucas Petrus](https://github.com/lucaspetrus)
+ [Noah Caldwell](https://github.com/noahnisbet)
 
- [Nicholas Adamski, Labs32](https://github.com/boscolio)
+###### Labs 30
+[Tomas Phillips](https://github.com/tomashphill)
+[Sean Byrne](https://github.com/ssbyrne89)
+[Henry Gultom](https://github.com/henryspg)
+[RJ Proctor](https://github.com/jproctor-rebecca)
 
- [Rassamy J. Soumphonphakdy, Labs32](https://github.com/rassamyjs)
+###### Labs 29
+[Liam Cloud Hogan](https://github.com/liam-cloud-hogan)
+[Steven Lee](https://github.com/StevenBryceLee)
+[Edwina Palmer](https://github.com/edwinapalmer)
+[Tristan Brown](https://github.com/Tristan-Brown1096)
 
- [Rebecca Duke Wiesenberg, Labs31](https://github.com/rdukewiesenb)
-
- [Reid Harris, Labs31](https://github.com/codealamode)
-
- [Lucas Petrus, Labs31](https://github.com/lucaspetrus)
-
- [Noah Caldwell, Labs31](https://github.com/noahnisbet)
-
- [Tomas Phillips, Labs30](https://github.com/tomashphill)
-
- [Sean Byrne, Labs30](https://github.com/ssbyrne89)
-
- [Henry Gultom, Labs30](https://github.com/henryspg)
- 
- [RJ Proctor, Labs30](https://github.com/jproctor-rebecca)
-
- [Liam Cloud Hogan, Labs29](https://github.com/liam-cloud-hogan)
- 
- [Steven Lee, Labs29](https://github.com/StevenBryceLee)
-
- [Edwina Palmer, Labs29](https://github.com/edwinapalmer)
-
- [Tristan Brown, Labs29](https://github.com/Tristan-Brown1096)
- 
-![Team2 Cross-functional Whole Team Structure](assets/HRF_cross_functional_product_dev_team_rjproctor.png)
 
  ## License
-
  This project is licensed under the terms of the MIT license.


### PR DESCRIPTION
The old documentation was good, but we wanted to create a consistent style across codebases for the main README.md files located at the root of each repository (FE, BE, DS)
This request
- renames README.md to Labs32README.md so it may be referenced while we craft the new document
- replaces README.md with the start of a new document

Future work on this file will need to improve and add to:
- Our Role section, to describe what this team (and past teams) has done and what the next team can improve on.
- Files section, to give a brief summary of how each piece of this repository (files, folders, etc.) has been used and why it's there.
- any additional installation steps that are currently missing from the process


This is the first step in improving the new documentation.  The next step will be improving this document. Then, we can create READMEs for each folder that explain what each file in that folder does, who created it, and for what purpose.
Please help us make it better by adding anything that may be helpful to future teams.