### PR TITLE
Remove any instance of `\n` from `get_precedent_cases` list

### DIFF
--- a/app/ocr.py
+++ b/app/ocr.py
@@ -487,7 +487,7 @@ class BIACase:
                     final_cases.append(clean_cases[l][3:])
             elif clean_cases[l] not in final_cases:                
                 final_cases.append(clean_cases[l])
-        return final_cases
+        return [s.replace('\n', ' ').replace('  ', ' ') for s in final_cases]
 
     def get_statutes(self) -> dict: 
         """Returns statutes mentioned in a given .txt document as a dictionary: {"""


### PR DESCRIPTION
Added one line to remove instances of `\n`, if two are present, the double space will be removed. This case--`084d0556-5748-4687-93e3-394707be6cc0`--is a perfect example of both cases. Future implementations should account for other unwanted charecters.