### PR TITLE
Fix data format coming into judge visualization endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,9 +12,8 @@ import os
 
 from boto3.session import Session
 from botocore.exceptions import ClientError, ConnectionError
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi import Request, FastAPI
 from dotenv import load_dotenv
 
 from app.ocr import make_fields

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from boto3.session import Session
 from botocore.exceptions import ClientError, ConnectionError
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi import Request, FastAPI
 from dotenv import load_dotenv
 
 from app.ocr import make_fields
@@ -65,17 +66,19 @@ async def pdf_ocr(uuid: str):
     except ClientError:
         return {"status": f"File not found: {uuid}.pdf"}
 
+from fastapi import Request, FastAPI
+
 
 @app.post("/vis/judges/{judge_id}")
-def vis_judges(judge_data: str):
+async def vis_judges(request: Request):
     """
-    Takes judge_data from BE and stores it in a dataframe.
+    Receives judge_data from BE and stores it in a dataframe.
     Creates a fig object with the bar chart info and returns it in json format.
     Features: protected grounds
     """
-
-    jsondata = json.loads(judge_data)['data']
-
+    # Receive data from backend and convert to dataframe
+    jsonstring = await request.body()
+    jsondata = json.loads(jsonstring)['data']
     df = pd.DataFrame.from_dict(jsondata)
 
     # creating df for graphing


### PR DESCRIPTION
## Description

Fixes #133 which expected data submitted to the `/vis/judges/{judge_id}` endpoint to be a string. This tells the endpoint to expect a request where we access the body of that request to extract the json data.
- Adds `async` to route

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes