### PR TITLE
Feature/bar chart

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,8 +17,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 
 from app.ocr import make_fields
+from app.visualizations import get_stacked_bar_chart
 
-import plotly.graph_objects as go
 import pandas as pd
 import json
 
@@ -65,58 +65,30 @@ async def pdf_ocr(uuid: str):
     except ClientError:
         return {"status": f"File not found: {uuid}.pdf"}
 
-from fastapi import Request, FastAPI
-
 
 @app.post("/vis/judges/{judge_id}")
 async def vis_judges(request: Request):
     """
-    Receives judge_data from BE and stores it in a dataframe.
-    Creates a fig object with the bar chart info and returns it in json format.
-    Features: protected grounds
+    Receives judge_data from BE and stores it in a dataframe.  
+    Creates a dictionary with multiple graphs, one graph for each feature.  
+    Features: protected grounds, gender, country_of_origin.  
+    returns the graphs in json format.  
     """
+
     # Receive data from backend and convert to dataframe
     jsonstring = await request.body()
     jsondata = json.loads(jsonstring)['data']
     df = pd.DataFrame.from_dict(jsondata)
 
-    # creating df for graphing
-    outcomes_list = ['Denied', 'Granted', 'Remanded', 'Sustained', 'Terminated']
+    chart_1 = get_stacked_bar_chart(df, 'protected_grounds')
+    chart_2 = get_stacked_bar_chart(df, 'gender')
+    chart_3 = get_stacked_bar_chart(df, 'country_of_origin')
 
-    df_protected_grounds = df.groupby('case_outcome').protected_grounds.value_counts().unstack(0)
-    df_protected_grounds = df_protected_grounds.fillna(0)
+    charts_dict = {'bar_protected_grounds': chart_1,
+                   'bar_gender': chart_2,
+                   'bar_country_of_origin': chart_3}
 
-    # creating new column with an outcome a judge might not have had
-    for outcome in outcomes_list:
-        if outcome not in df_protected_grounds.columns:
-            df_protected_grounds[outcome] = 0.0
-
-    # rearranging for same order, but might be unnessessary bc of go object
-    df_protected_grounds = df_protected_grounds[outcomes_list]
-
-    # creating the graph
-    fig = go.Figure(data=[
-        go.Bar(name='Denied',
-               x=list(df_protected_grounds.index),
-               y=df_protected_grounds['Denied']),
-        go.Bar(name='Granted',
-               x=list(df_protected_grounds.index),
-               y=df_protected_grounds['Granted']),
-        go.Bar(name='Remanded',
-               x=list(df_protected_grounds.index),
-               y=df_protected_grounds['Remanded']),
-        go.Bar(name='Sustained',
-               x=list(df_protected_grounds.index),
-               y=df_protected_grounds['Sustained']),
-        go.Bar(name='Terminated',
-               x=list(df_protected_grounds.index),
-               y=df_protected_grounds['Terminated'])
-    ])
-
-    # Change the bar mode - stack vs group
-    fig.update_layout(barmode='stack')
-
-    return fig.to_json()
+    return json.dumps(charts_dict)
 
 
 @app.get("/vis/circuits/{circuit_id}")

--- a/app/visualizations.py
+++ b/app/visualizations.py
@@ -1,0 +1,22 @@
+import plotly.graph_objects as go
+
+
+def get_stacked_bar_chart(df, feature):
+    """Takes dataframe and feature name (str) and returns a graph figure
+    in json format for that feature as the x-axis"""
+
+    outcomes_list = ['Denied', 'Granted', 'Remanded', 'Sustained', 'Terminated']
+    df = df.groupby(feature)['case_outcome'].value_counts().unstack(fill_value=0)
+
+    fig_data = []
+    for outcome in outcomes_list:
+        if outcome in df.columns:
+            temp = go.Bar(name= outcome,
+                            x=list(df.index),
+                            y=df[outcome])
+            fig_data.append(temp)
+
+    fig = go.Figure(fig_data)
+    fig.update_layout(barmode='stack')
+
+    return fig.to_json()

--- a/notebooks/Labs34_Bar_Chart.ipynb
+++ b/notebooks/Labs34_Bar_Chart.ipynb
@@ -1,0 +1,188 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Labs34_Bar_Chart",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "rgFS-IM8GYTs"
+      },
+      "source": [
+        "# import\n",
+        "import pandas as pd\n",
+        "import numpy as np\n",
+        "import random\n",
+        "import plotly.express as px\n",
+        "import plotly.graph_objects as go\n",
+        "import seaborn as sns\n",
+        "import matplotlib.pyplot as plt\n",
+        "import json\n",
+        "import requests\n",
+        "from plotly.subplots import make_subplots\n"
+      ],
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "edjH_3X6KCnF"
+      },
+      "source": [
+        "# Bar chart"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ZsLgyRSTKGEm"
+      },
+      "source": [
+        "# run this to create df_web\n",
+        "\n",
+        "web_url = \"https://asylum-a-api.herokuapp.com\"\n",
+        "endpoint = \"/judges/1/cases\"\n",
+        "\n",
+        "# web_url = \"https://asylum-a-api.herokuapp.com\"\n",
+        "# endpoint = \"/cases\"\n",
+        "jsondata_2 = {\"judge_id\":2,\"first_name\":\"Patricia\",\"last_name\":\"Cole\",\"judge_county\":\"Virginia Falls\",\"appointed_by\":\"Janet Reno\",\"case_id\":\"099f113a-3514-45be-a2c7-9257eded3fe7\",\"case_url\":\"https://hrf-asylum-cases.s3.amazonaws.com/2ff54195-ce30-456c-be63-2a6c765bdce2.pdf\",\"case_number\":\"A079-531-484\",\"case_date\":\"2012-08-30T00:00:00.000Z\",\"case_outcome\":\"Granted\",\"country_of_origin\":\"El Salvador\",\"protected_grounds\":\"Political Opinion\",\"application_type\":\"initial\",\"case_origin_city\":\"Los Angeles\",\"case_origin_state\":\"CA\",\"gender\":\"Female\",\"appellate\":False,\"status\":\"approved\"},{\"judge_id\":2,\"first_name\":\"Patricia\",\"last_name\":\"Cole\",\"judge_county\":\"Virginia Falls\",\"appointed_by\":\"Janet Reno\",\"case_id\":\"75a1fb1b-1ffe-45d6-b347-9ef67d4b9180\",\"case_url\":\"https://hrf-asylum-cases.s3.amazonaws.com/2ff54195-ce30-456c-be63-2a6c765bdce2.pdf\",\"case_number\":\"A089-207-04\",\"case_date\":\"2012-01-31T00:00:00.000Z\",\"case_outcome\":\"Sustained\",\"country_of_origin\":\"Honduras\",\"protected_grounds\":\"Nationality\",\"application_type\":\"initial\",\"case_origin_city\":\"Imperial\",\"case_origin_state\":\"CA\",\"gender\":\"Female\",\"appellate\":False,\"status\":\"approved\"},{\"judge_id\":2,\"first_name\":\"Patricia\",\"last_name\":\"Cole\",\"judge_county\":\"Virginia Falls\",\"appointed_by\":\"Janet Reno\",\"case_id\":\"04fbe436-da2c-4e20-9cfb-2221ad8e1f29\",\"case_url\":\"https://hrf-asylum-cases.s3.amazonaws.com/2ff54195-ce30-456c-be63-2a6c765bdce2.pdf\",\"case_number\":\"A044-857-956\",\"case_date\":\"2011-12-15T00:00:00.000Z\",\"case_outcome\":\"Terminated\",\"country_of_origin\":\"Mexico\",\"protected_grounds\":\"Political Opinion\",\"application_type\":\"initial\",\"case_origin_city\":\"San Antonio\",\"case_origin_state\":\"TX\",\"gender\":\"Female\",\"appellate\":False,\"status\":\"approved\"}\n",
+        "\n",
+        "#jsondata = requests.get(web_url+endpoint).json()['data']\n",
+        "\n",
+        "df_web = pd.DataFrame.from_dict(jsondata_2)\n",
+        "\n",
+        "keep_cols = [\n",
+        "    'case_outcome',\n",
+        "    'country_of_origin',\n",
+        "    'protected_grounds',\n",
+        "    'gender',\n",
+        "]\n",
+        "\n",
+        "# filter dataframe\n",
+        "df_web = df_web[keep_cols]\n",
+        "df_web"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "zwfPULeGxxDI"
+      },
+      "source": [
+        "# this is the function we are using. Can make any changes.\n",
+        "\n",
+        "def create_fig(df, feature):\n",
+        "  # can also change this outcomes list for the outcomes we want\n",
+        "  outcomes_list = ['Denied', 'Granted', 'Remanded', 'Sustained', 'Terminated']\n",
+        "  df = df_web.groupby(feature)['case_outcome'].value_counts().unstack(fill_value=0)\n",
+        "\n",
+        "  fig_data = []\n",
+        "  for outcome in outcomes_list:\n",
+        "      if outcome in df.columns:\n",
+        "          temp = go.Bar(name= outcome,\n",
+        "                        x=list(df.index),\n",
+        "                        y=df[outcome])\n",
+        "          fig_data.append(temp)\n",
+        "\n",
+        "  fig = go.Figure(fig_data)\n",
+        "\n",
+        "  # Lots on different things you can do here:\n",
+        "  # barmode stack or group\n",
+        "  fig.update_layout(barmode='stack')\n",
+        "\n",
+        "  # This is how we will return it on the API\n",
+        "  # return fig.to_json()\n",
+        "  return fig"
+      ],
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "E3ygkn58xzTr"
+      },
+      "source": [
+        "# test with different features, just change the name.\n",
+        "fig = create_fig(df_web, 'protected_grounds')\n",
+        "fig.show()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "s2Sbe8KqC99i"
+      },
+      "source": [
+        "# to test:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "AfR1DXtG1OZO"
+      },
+      "source": [
+        "def create_fig(df, feature):\n",
+        "  # can also change this outcomes list for the outcomes we want\n",
+        "  outcomes_list = ['Denied', 'Granted', 'Remanded', 'Sustained', 'Terminated']\n",
+        "  df = df_web.groupby(feature)['case_outcome'].value_counts().unstack(fill_value=0)\n",
+        "\n",
+        "  fig_data = []\n",
+        "  for outcome in outcomes_list:\n",
+        "      if outcome in df.columns:\n",
+        "          temp = go.Bar(name= outcome,\n",
+        "                        x=list(df.index),\n",
+        "                        y=df[outcome])\n",
+        "          fig_data.append(temp)\n",
+        "\n",
+        "  fig = go.Figure(fig_data)\n",
+        "\n",
+        "  # Lots on different things you can do here:\n",
+        "  # barmode stack or group\n",
+        "  fig.update_layout(barmode='stack')\n",
+        "\n",
+        "  # This is how we will return it on the API\n",
+        "  return fig.to_json()\n",
+        " "
+      ],
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3Ts6N1R_C54h"
+      },
+      "source": [
+        "#  create json fig to graph with create_fig function\n",
+        "fig_json = create_fig(df_web, 'protected_grounds')\n",
+        "\n",
+        "# graph it!\n",
+        "to_graph = json.loads(fig_json)\n",
+        "fig = go.Figure(to_graph)\n",
+        "fig.show()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
## Description
After the previous vis/judges api route worked well, I went back and added functionality and cleaned up the code. 
Currently the DS team can manually edit what features they want to display on the x-axis, and multiple graphs can be returned at the same time for the web team to parse and implement.
The next step is to decide what we will add to the graph on the DS side and implement those additions.

- Created a visualizations.py file to house new function called get_stacked_bar_chart that creates a bar chart and returns the chart in json format
- Streamlined vis/judges endpoint to use get_stacked_bar_chart to create multiple bar graphs and return all of them in a dictionary in json format
- Added my personal notebook called Labs34_bar_chart

## Type of change

Please delete options that are not relevant.

- [x]  New feature (non-breaking change which adds functionality)
- [ ]  This change requires a documentation update

## Checklist:

- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  I have removed unnecessary comments/console logs from my code
- [x]  I have made corresponding changes to the documentation if necessary (optional)
- [x]  My changes generate no new warnings
- [x]  I have checked my code and corrected any misspellings
- [x]  No duplicate code left within changed files
- [x]  Size of pull request kept to a minimum
- [x]  Pull request description clearly describes changes made & motivations for said changes