### PR TITLE
Added notebook for get_credibility method

### DIFF
--- a/notebooks/priority_fields/get_cred.ipynb
+++ b/notebooks/priority_fields/get_cred.ipynb
@@ -1,0 +1,199 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "get_cred.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Q9JJUSkko615"
+      },
+      "source": [
+        "import os\n",
+        "import pandas as pd\n",
+        "import requests\n",
+        "import spacy\n",
+        "import string\n",
+        "from typing import List, Tuple, Union, Callable, Dict, Iterator\n",
+        "from collections import defaultdict\n",
+        "from difflib import SequenceMatcher\n",
+        "from spacy.matcher import Matcher, PhraseMatcher\n",
+        "from spacy.tokens import Doc, Token, Span\n",
+        "from spacy.matcher import Matcher\n",
+        "!python -m spacy download en_core_web_md"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "_LidzBBWo-Rl"
+      },
+      "source": [
+        "matcher = Matcher(nlp.vocab)\n",
+        "\n",
+        "# This pattern was created from the available cases under the redacted \n",
+        "# directory in our shared HRF google drive\n",
+        "\n",
+        "pattern = [\n",
+        "            # most specific phrases\n",
+        "            [{\"LOWER\": \"court\"}, {\"LOWER\": \"finds\"}, {\"LOWER\": \"respondent\"}, {\"LOWER\": \"generally\"}, {\"LOWER\": \"credible\"}],\n",
+        "            [{\"LOWER\": \"court\"}, {\"LOWER\": \"finds\"}, {\"LOWER\": \"respondent\"}, {\"LOWER\": \"testimony\"}, {\"LOWER\": \"credible\"}],\n",
+        "            [{\"LOWER\": \"court\"}, {\"LOWER\": \"finds\"}, {\"LOWER\": \"respondent\"}, {\"LOWER\": \"credible\"},\n",
+        "\n",
+        "            # standard phrases\n",
+        "            [{\"LOWER\": \"credible\"}, {\"LOWER\": \"witness\"}],\n",
+        "            [{\"LOWER\": \"generally\"}, {\"LOWER\": \"consistent\"}],\n",
+        "            [{\"LOWER\": \"internally\"}, {\"LOWER\": \"consistent\"}],\n",
+        "            [{\"LOWER\": \"sufficiently\"}, {\"LOWER\": \"consistent\"}],\n",
+        "            [{\"LOWER\": \"testified\"}, {\"LOWER\": \"credibly\"}],\n",
+        "            [{\"LOWER\": \"testimony\"}, {\"LOWER\": \"credible\"}],\n",
+        "            [{\"LOWER\": \"testimony\"}, {\"LOWER\": \"consistent\"}],\n",
+        "\n",
+        "            # least specific phrases\n",
+        "            [{\"LOWER\": \"coherent\"}],\n",
+        "            [{\"LOWER\": \"plausible\"}]\n",
+        "          ]\n",
+        "\n",
+        "matcher.add('credibility', pattern)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "prk6kZuq6jQH"
+      },
+      "source": [
+        "def similar(target_phrases, file):\n",
+        "    \"\"\"GET RID OF PUNCT\"\"\"\n",
+        "    matcher = Matcher(nlp.vocab)\n",
+        "    matcher.add('target_phrases', target_phrases)\n",
+        "    \n",
+        "    return matcher(file, as_spans=True)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FwF5VUzEt_jm"
+      },
+      "source": [
+        "def get_credibility(self):  \n",
+        "    \"\"\"\n",
+        "    Returns whether or not the Respondent was identified as credible by their\n",
+        "    assigned judge / court. \n",
+        "    \"\"\" \n",
+        "    pattern = [\n",
+        "                # most important phrasing \n",
+        "                [{\"LOWER\": \"court\"}, {\"LOWER\": \"finds\"}, {\"LOWER\": \"respondent\"}, {\"LOWER\": \"generally\"}, {\"LOWER\": \"credible\"}],\n",
+        "                [{\"LOWER\": \"court\"}, {\"LOWER\": \"finds\"}, {\"LOWER\": \"respondent\"}, {\"LOWER\": \"testimony\"}, {\"LOWER\": \"credible\"}],\n",
+        "                [{\"LOWER\": \"court\"}, {\"LOWER\": \"finds\"}, {\"LOWER\": \"respondent\"}, {\"LOWER\": \"credible\"},\n",
+        "\n",
+        "                # next in omportance\n",
+        "                [{\"LOWER\": \"credible\"}, {\"LOWER\": \"witness\"}],\n",
+        "                [{\"LOWER\": \"generally\"}, {\"LOWER\": \"consistent\"}],\n",
+        "                [{\"LOWER\": \"internally\"}, {\"LOWER\": \"consistent\"}],\n",
+        "                [{\"LOWER\": \"sufficiently\"}, {\"LOWER\": \"consistent\"}],\n",
+        "                [{\"LOWER\": \"testified\"}, {\"LOWER\": \"credibly\"}],\n",
+        "                [{\"LOWER\": \"testimony\"}, {\"LOWER\": \"credible\"}],\n",
+        "                [{\"LOWER\": \"testimony\"}, {\"LOWER\": \"consistent\"}],\n",
+        "\n",
+        "                # least importance \n",
+        "                [{\"LOWER\": \"coherent\"}],\n",
+        "                [{\"LOWER\": \"plausible\"}]\n",
+        "              ]\n",
+        "\n",
+        "    similar_cred = similar(target_phrases=pattern, file=self.doc)\n",
+        "    \n",
+        "    if similar_cred:\n",
+        "        # following code adds matches to a list, may or may not be needed in\n",
+        "        # the front end.\n",
+        "        \n",
+        "        # cred = []\n",
+        "        # for phrase in similar_cred:\n",
+        "        #     if phrase.text.lower() not in cred:\n",
+        "        #         cred.append(phrase.text.lower())\n",
+        "\n",
+        "        return 'Respondent was found credible' # this could be changed to bool\n",
+        "\n",
+        "    return 'Respondent was not found credible' # same for this"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "OI5m6w8F6WUh"
+      },
+      "source": [
+        "# Non-credible wording:\n",
+        "\n",
+        "# In some decisions, the immigration judge will find parts of the testimony \n",
+        "# “problematic,” or question its plausibility, without actually reaching a \n",
+        "# conclusion that the testimony lacked credibility. In such cases, argue on \n",
+        "# appeal that the statutory presumption of credibility should apply.\n",
+        "\n",
+        "# Exhibited behavior that does not always seem reasonable, nor plausible, \n",
+        "# nor....worthy of belief because of inconsistent behavior and inconsistent \n",
+        "# statements.\n",
+        "\n",
+        "# Seemed rehearsed, lacked the ring of truth\n",
+        "# Highly implausible\n",
+        "# Couldn't produce\n",
+        "# Perceived lack of rationality, persuasiveness, and consistency\n",
+        "# Did not cry during testimony, appeared highly peeved\n",
+        "# Did not request asylum immediately upon entry to US\n",
+        "\n",
+        "\n",
+        "\n",
+        "# Credible wording:\n",
+        "\n",
+        "# Findings of fact and conclusion of law\n",
+        "# A. Credibility\n",
+        "# The court finds the respondent to have testified credibly\n",
+        "\n",
+        "# Analysis\n",
+        "# B. Credibility and Corroboration\n",
+        "# The parties stipulated that the respondent filed a credible claim. The court finds that () testified credibly.\n",
+        "\n",
+        "# Asylum\n",
+        "# A. Credibility and Corroboration\n",
+        "# the Court finds Respondent's testimony to be credible, provided a sufficiently detailed, plausible, and internally consistent accounts of the events\n",
+        "\n",
+        "# Decisions and orders of the immigration judge\n",
+        "# III. Credibility and Corroboration\n",
+        "# the Court shall find that Respondent is generally credible.\n",
+        "\n",
+        "# Legal Standards and Analysis\n",
+        "# A. Credibility\n",
+        "# Court finds that Respondent's testimony was credible. ...testimony was detailed, plausible, internally consistent, and consistent with documentary evidence.\n",
+        "# credible witnesses corroborated the Respondent's claim.\n",
+        "\n",
+        "# Findings of fact and conclusion of law\n",
+        "# A. Credibility\n",
+        "# Court finds the Respondent to have testified credibly"
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Created a small function that looks for phrases generally indicative of a trustworthy/credible Respondent. At the moment it returns a simple sentence stating whether the respondent is credible or not, but can easily be changed to whatever we need.

## Type of change

Please delete options that are not relevant.

- [x]  New feature (non-breaking change which adds functionality)

## Checklist:

- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  I have removed unnecessary comments/console logs from my code
- [x]  I have checked my code and corrected any misspellings
- [x]  No duplicate code left within changed files
- [x]  Size of pull request kept to a minimum
- [x]  Pull request description clearly describes changes made & motivations for said changes