### PR TITLE
Updates check_for_one_year and get_protected_grounds

### DIFF
--- a/app/ocr.py
+++ b/app/ocr.py
@@ -138,7 +138,8 @@ def in_parenthetical(match, doc):
     used in protected grounds in order to improve accuracy
     '''
     open_parens = 0
-    for i in range(match.end, len(doc)):
+    #search the rest of the sentence
+    for i in range(match.end, match.sent.end):
         if doc[i].text == '(':
             open_parens += 1
         elif doc[i].text == ')':
@@ -146,8 +147,6 @@ def in_parenthetical(match, doc):
                 open_parens -= 1
             else:
                 return True
-        elif doc[i] in {'.', '?', '!'}:
-            return False
     return False
 
 """
@@ -255,7 +254,7 @@ class BIACase:
         self.indigenous_status = self.get_indigenous_status(),
         self.applicant_language = self.get_applicant_language(),
         self.credibility = self.get_credibility(),
-        self.one_year = self.check_for_one_year_new(),
+        self.one_year = self.check_for_one_year(),
         self.precedent_cases = self.get_precedent_cases(),
         self.statutes = self.get_statutes(),
 
@@ -458,6 +457,10 @@ class BIACase:
         potential_grounds = similar(self.doc, pattern)
 
         for match in potential_grounds:
+            # skip matches that appear in parenthesis, the opinion is probably
+            # just quoting a list of all the protected grounds in the statute
+            if in_parenthetical(match, self.doc):
+                continue
             # remove 'nationality act' from potential_grounds
             if match.text.lower() == 'nationality' \
             and 'act' not in match.sent.text.lower() \
@@ -957,41 +960,37 @@ class BIACase:
         #             return 'N/A to case'
         return "Test"
 
-    def check_for_one_year_new(self) -> bool:
+    def check_for_one_year(self) -> bool:
         """
         Checks whether or not the asylum-seeker argued to be exempt from the
         one-year guideline.
-        
-        Returns true if the phrase "within one-year" appears in the document.
-        Also returns true if a time-based word appears in the same sentence
-        with "extraordinary circumstances" or "changed circumstances" or
-        "untimely application". Otherwise, returns False.
-        
+
+        Returns true if the phrases "within one-year", "untimely application",
+        "extraordinary circumstances" or "changed circumstances" appeaer in the
+        same sentence as a time-based word. Otherwise returns False.
         """
-        year_pattern = [
-            [{'LOWER':'within'}, {'LOWER': {'IN':['1', 'one']}}, 
-             {'LOWER': '-', 'OP': '?'}, {'LOWER': 'year'}]
-        ]
-        matcher = Matcher(nlp.vocab)
-        matcher.add('year pattern', year_pattern)
-        matches = matcher(self.doc, as_spans=True)
-        if matches:
-            return True
-        matcher.remove('year pattern')
-        
-        secondary_terms = {'year', 'delay', 'time', 'period', 'deadline'}
+        time_terms = {'year', 'delay', 'time', 'period', 'deadline'}
+        # The 'OP':'?' notation means this token is optional, it will match
+        # sequences with the token and without the token.
         circumstance_pattern = [
-            [{'LEMMA': {'IN':['change', 'extraordinary']}}, 
+            [{'LEMMA': {'IN':['change', 'extraordinary']}},
              {'LOWER': {'IN':['"', '”']}, 'OP': '?'}, {'LEMMA': 'circumstance'}]
         ]
         application_pattern = [
             [{'LOWER':'untimely'}, {'LOWER':'application'}]
         ]
+        year_pattern = [
+            [{'LOWER':'within'}, {'LOWER': {'IN':['1', 'one']}},
+             {'LOWER': '-', 'OP': '?'}, {'LOWER': 'year'}]
+        ]
+        matcher = Matcher(nlp.vocab)
+        matcher.add('year pattern', year_pattern)
         matcher.add('circumstance pattern', circumstance_pattern)
         matcher.add('application pattern', application_pattern)
-        matches = matcher(self.doc, as_spans=True)
+        matches = matcher(self.doc, as_spans=True)   
+
         for match in matches:
             for token in match.sent:
-                if token.lemma_ in secondary_terms:
+                if token.lemma_ in time_terms:
                     return True
         return False

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -131,7 +131,7 @@ def similar_outcome(str1, str2):
 
     return False
 
-def in_parenthetical(match, doc):
+def in_parenthetical(match):
     '''
     Checks for text wrapped in parathesis, and removes any
     returned protected grounds if they we're wrapped in parenthesis
@@ -140,9 +140,9 @@ def in_parenthetical(match, doc):
     open_parens = 0
     #search the rest of the sentence
     for i in range(match.end, match.sent.end):
-        if doc[i].text == '(':
+        if match.doc[i].text == '(':
             open_parens += 1
-        elif doc[i].text == ')':
+        elif match.doc[i].text == ')':
             if open_parens > 0:
                 open_parens -= 1
             else:
@@ -459,7 +459,7 @@ class BIACase:
         for match in potential_grounds:
             # skip matches that appear in parenthesis, the opinion is probably
             # just quoting a list of all the protected grounds in the statute
-            if in_parenthetical(match, self.doc):
+            if in_parenthetical(match):
                 continue
             # remove 'nationality act' from potential_grounds
             if match.text.lower() == 'nationality' \


### PR DESCRIPTION
## Description

The in_parenthetical() method is updated to use spaCy to more accurately find the end of a sentence so as to stop looking for parenthesis. 

The get_protected_grounds method is updated to not count grounds that only appear in parenthesis. This improves accuracy by several percentage points, as grounds listed only in parentheses are generally a judge listing all of the grounds in the statute, rather than the grounds that the applicant is arguing.

The check_for_one_year method is updated to check for time-based words regardless of which phrase has been matched. This preserves 100% accuracy on the training data while slightly improving efficiency, and improving readability.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
