### PR TITLE
added the loop to hit up the endpoint

### DIFF
--- a/notebooks/get_aws.ipynb
+++ b/notebooks/get_aws.ipynb
@@ -40,8 +40,8 @@
     "# creating a session and connecting to our s3 bucket. you have to manually enter the \n",
     "# access keys - or at least i couldn't get them from .env\n",
     "\n",
-    "ACCESS_KEY = 'access_key'\n",
-    "SECRET_ACCESS_KEY = 'secret_access_key'\n",
+    "ACCESS_KEY = 'your-access-key'\n",
+    "SECRET_ACCESS_KEY = 'your-secret-access-key'\n",
     "\n",
     "session = Session(aws_access_key_id=ACCESS_KEY, \n",
     "                  aws_secret_access_key=SECRET_ACCESS_KEY)\n",
@@ -68,18 +68,35 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# reloading the cases into the ds_cases table using the endpoint setup\n",
+    "# through elasticbeanstalk\n",
+    "\n",
+    "\n",
+    "API_URL = 'http://labs37-hrf-asylum-b-dev.us-east-1.elasticbeanstalk.com/pdf-ocr'        # your endpoint will go here\n",
+    "\n",
+    "for file in filenames:\n",
+    "    file = file.strip('.pdf')\n",
+    "    re.get(f'{API_URL}/{file}')"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
     "# getting the files stored in the bucket. note they currently download to\n",
-    "# the notebook folder. change to your prefer in open(). these files are needed\n",
+    "# the notebooks folder. change in open(). these files are needed\n",
     "# to check and calibrate the accuracy of the ocr\n",
     "\n",
     "for i in range(len(df)):\n",
     "    r = re.get(df['AWS link'][i])\n",
-    "#     print(r)\n",
-    "#     open('../' + name, 'wb').write(r.content)"
+    "    print(r)\n",
+    "    open('../' + name, 'wb').write(r.content)"
    ]
   }
  ],


### PR DESCRIPTION
## Description

Edited the get_aws notebook to include the loop that sends a GET request to our endpoint to process each .pdf and populate the ds_cases table. New users will only have to edit the access keys and the API URL.

Fixes # (issue)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [X] I have made corresponding changes to the documentation if necessary (optional)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes
