### PR TITLE
Removed the get_decision_type function and from the to_dict function …

### DIFF
--- a/app/ocr.py
+++ b/app/ocr.py
@@ -515,7 +515,7 @@ class BIACase:
         gang_match = get_matches(gang_list, 'Gang', self.doc)
 
         # Printing full_text[judge_match2[0][1]:judge_match2[0][2]] gives word
-        # it matches on, can put in the [0] a for loop to see all matche78s
+        # it matches on, can put in the [0] a for loop to see all matches
         if len(violence_match) != 0:
             terms_list.append('Violent')
         if len(family_match) != 0:

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -130,7 +130,6 @@ class BIACase:
         return {
             'uuid': self.uuid,
             'panel_members': self.get_panel() or 'Unknown',
-            'decision_type': self.get_decision_type() or 'Unknown',
             'application_type': self.get_application() or "Unknown",
             'decision_date': self.get_date() or 'Unknown',
             'country_of_origin': self.get_country_of_origin() or 'Unknown',

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -130,7 +130,6 @@ class BIACase:
         return {
             'uuid': self.uuid,
             'panel_members': ', '.join(self.get_panel()) or 'Unknown',
-            'decision_type': self.get_decision_type() or 'Unknown',
             'application_type': self.get_application() or "Unknown",
             'decision_date': self.get_date() or 'Unknown',
             'country_of_origin': self.get_country_of_origin() or 'Unknown',
@@ -388,11 +387,6 @@ class BIACase:
                         outcome.add(k)
         return "; ".join(list(outcome))
 
-    def get_decision_type(self) -> str:
-        return "Appellate" if len(self.get_panel()) > 1 else "Initial"
-        # It seems decision_type is looking for appellate decision or else
-        # intial decision, not immigration court decision.
-
     def get_outcome(self) -> str:
         """
         • Returns the outcome of the case. This will appear after 'ORDER'
@@ -521,7 +515,7 @@ class BIACase:
         gang_match = get_matches(gang_list, 'Gang', self.doc)
 
         # Printing full_text[judge_match2[0][1]:judge_match2[0][2]] gives word
-        # it matches on, can put in the [0] a for loop to see all matches
+        # it matches on, can put in the [0] a for loop to see all matche78s
         if len(violence_match) != 0:
             terms_list.append('Violent')
         if len(family_match) != 0:


### PR DESCRIPTION
…considering there are no apellate cases anymore

## Description

Since there are no more appellate cases we removed the get_decision_type function and the call in to_dict
Fixes # (reduces confusion by removing unnecessary code.

Video: https://www.loom.com/share/76cd4bc34b764f09bbe6f4db9f842da3

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes


Co-authors: Zunera Bokhari, Trevor Dewalt