### PR TITLE
Refactor ocr.py to scrape for immigration court cases instead of BIA cases

### DIFF
--- a/app/ocr.py
+++ b/app/ocr.py
@@ -215,8 +215,7 @@ class IJCase:
                 return s
         """
         primary_pattern = [
-            [{"LOWER": "date"}, {"LOWER": "of"},
-             {"LOWER": "this"}, {"LOWER": "notice"}]
+            [{"LOWER": "date"}, {"LOWER": ":"}]
         ]
         # instantiate a list of pattern matches
         spans = similar(self.doc, primary_pattern)
@@ -331,7 +330,6 @@ class IJCase:
         for match in potential_grounds:
             # remove 'nationality act' from potential_grounds
             if not in_parenthetical(match):
-
                 if match.text.lower() == 'nationality' \
                         and 'act' not in match.sent.text.lower() \
                         and 'nationality' not in confirmed_matches:

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -18,7 +18,7 @@ def make_fields(uuid, file) -> dict:
     pages = convert_from_bytes(file, dpi=90)
     text = map(pytesseract.image_to_string, pages)
     string = " ".join(text)
-    case_data = BIACase(uuid, string).to_dict()
+    case_data = IJCase(uuid, string).to_dict()
     return case_data
 
 
@@ -106,7 +106,7 @@ def in_parenthetical(match):
     return False
 
 
-class BIACase:
+class IJCase:
     """
     The following defines the BIACase Class. When receiving a court doc,
     we use this to extract info for the desired fields/info

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -7,7 +7,6 @@ from spacy.tokens import Doc, Span
 from spacy.matcher import Matcher, PhraseMatcher
 from typing import List, Iterator
 
-
 nlp = load("en_core_web_sm")
 
 
@@ -158,7 +157,7 @@ class IJCase:
         countries = sorted(gc.get_countries_by_names().keys())
         # remove U.S. and its territories from countries
         countries = set(countries)
-        non_matches = {"American Samoa", "Guam", "Northern Mariana Islands", "Puerto Rico", 
+        non_matches = {"American Samoa", "Guam", "Northern Mariana Islands", "Puerto Rico",
                        "United States", "United States Minor Outlying Islands", "U.S. Virgin Islands"}
         countries = countries.difference(non_matches)
 
@@ -216,8 +215,8 @@ class IJCase:
                 return s
         """
         primary_pattern = [
-            [{"LOWER": "date"}, {"LOWER": "of"}, 
-            {"LOWER": "this"}, {"LOWER": "notice"}]
+            [{"LOWER": "date"}, {"LOWER": "of"},
+             {"LOWER": "this"}, {"LOWER": "notice"}]
         ]
         # instantiate a list of pattern matches
         spans = similar(self.doc, primary_pattern)
@@ -394,17 +393,13 @@ class IJCase:
         at the end of the document.
         """
         outcomes = {
-            'remanded',
-            'reversal',
             'dismissed',
-            'sustained',
             'terminated',
             'granted',
             'denied',
-            'returned',
         }
         for token in self.doc:
-            if token.text in {"ORDER", 'ORDERED'}:
+            if token.text in {"ORDER", 'ORDERED', 'ORDERS'}:
                 start, stop = token.sent.start, token.sent.end + 280
                 outcome = self.doc[start:stop].text.strip().replace("\n", " ")
                 outcome = outcome.split('.')[0].lower()
@@ -447,7 +442,7 @@ class IJCase:
                 return state
             except:
                 return "Unknown"
-            
+
         return "Unknown"
 
     def get_city(self) -> str:
@@ -475,7 +470,7 @@ class IJCase:
                 return city
             except:
                 return "Unknown"
-                
+
         return "Unknown"
 
     def get_based_violence(self) -> List[str]:
@@ -552,7 +547,7 @@ class IJCase:
                         [{"LOWER": "court"}, {"LOWER": "finds"},
                          {"LOWER": "respondent"}, {"LOWER": "testimony"},
                          {"LOWER": "credible"}],
-                        [{"LOWER": "court"}, {"LOWER": "finds"}, 
+                        [{"LOWER": "court"}, {"LOWER": "finds"},
                          {"LOWER": "respondent"}, {"LOWER": "credible"}]]
 
         medium_scope = [[{"LOWER": "credible"}, {"LOWER": "witness"}],
@@ -563,10 +558,10 @@ class IJCase:
                         [{"LOWER": "testimony"}, {"LOWER": "credible"}],
                         [{"LOWER": "testimony"}, {"LOWER": "consistent"}]]
 
-        wide_scope = [[{"LEMMA": {"IN": ["coherent", 
-                                        "possible", 
-                                        "credible", 
-                                        "consistent"]}}]]
+        wide_scope = [[{"LEMMA": {"IN": ["coherent",
+                                         "possible",
+                                         "credible",
+                                         "consistent"]}}]]
 
         similar_narrow = similar(self.doc, narrow_scope)
         similar_medium = similar(self.doc, medium_scope)


### PR DESCRIPTION
## Description

This pull request is submitted to change the name of the BIACase class to IJCase class to reflect the decision that the application will not receive BIA appellate cases but will focus on initial immigration court cases.

In addition, the PR refactors the code in the following functions in ocr.py:

get_date
get_outcome
get_application  

These refactors are designed to more accurately scrape data from immigration court cases (as those cases follow a different pattern than BIA cases).

Fixes # (no number assigned)
- Fixes a bug in ocr.py due to path change from BIA cases to immigration cases

Co-authored with @EmilyAFlener and @mathewmahoneyds20 in pair-programming session.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes

https://www.loom.com/share/cebfe73b51fc4bf5946a7ba02ef7f0e0